### PR TITLE
AO-8631: make the test cases work with new AppOptics API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Changelog
 
+### Version 5.0.0
+* This is the first version that supports AppOptics metrics APIs. 
+* Some new methods are provided as aliases of the original ones.   
+* Legacy Librato source-based metrics/measurements are deprecated and no longer supported in this version.
+
+    _a) Source-based measurements are deprecated in AppOptics._
+    
+    _b) At least one `tags` is needed for submitting measurements._
+    
+    _c) `counters` is deprecated._
+
+Please refer to the README for a simple tutorial and AppOptics API documents for more details.
+
 ### Version 4.0.0
 * Removed username (email) from API connection credential
 * Updated License

--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ To iterate over your metrics:
 or use `list_all_metrics()` to iterate over all your metrics with
 transparent pagination.
 
-Let's now create a metric:
+Let's now create a measurement for a specific metric. The metric will be created if it does not exist:
 
 ```python
   api.submit("temperature", 80, tags={"city": "sf"})
+```
+
+There is also an alias which does the same thing (but in a more explicit name):
+
+```python
+  api.submit_measurement("temperature", 80, tags={"city": "sf"})
 ```
 
 View your metric names:
@@ -70,11 +76,11 @@ View your metric names:
       print(m.name)
 ```
 
-To retrieve a metric:
+To retrieve a metric or measurement:
 
 ```python
   # Retrieve metric metadata ONLY
-  gauge = api.get("temperature")
+  gauge = api.get("temperature")  # or use the alias: api.get_metric(...)
   gauge.name # "temperature"
 
   # Retrieve measurements from last 15 minutes
@@ -129,6 +135,18 @@ Delete a metric:
 
 ```python
   api.delete("temperature")
+```
+
+Aliases are provided for methods manipulating metrics and measurements:
+
+```python
+    create(...)     -> create_metric(...)
+    submit(...)     -> submit_measurement(...)
+    
+    update(...)     -> update_metric(...)
+    delete(...)     -> delete_metric(...)
+    get(...)        -> get_metric(...)
+    get_tagged(...) -> get_measurements(...)
 ```
 
 ## Sending measurements in batch mode

--- a/appoptics_metrics/__init__.py
+++ b/appoptics_metrics/__init__.py
@@ -54,22 +54,23 @@ def sanitize_no_op(metric_name):
 class AppOpticsConnection(object):
     """AppOptics API Connection.
     Usage:
-    >>> conn = AppOpticsConnection(api_key)
-    >>> conn.list_metrics()
+    conn = AppOpticsConnection(api_key)
+    conn.list_metrics()
     [...]
     """
 
     def __init__(self, api_key, hostname=HOSTNAME, base_path=BASE_PATH, sanitizer=sanitize_no_op,
-                 protocol="https", tags={}):
+                 protocol="https", tags=None):
         """Create a new connection to AppOptics Metrics.
         Doesn't actually connect yet or validate until you make a request.
 
         :param api_key: The API Key (token) to use to authenticate
         :type api_key: str
         """
+        tags = tags or {}
         try:
             self.api_key = api_key.encode('ascii')
-        except:
+        except Exception:
             raise TypeError("AppOptics only supports ascii for the credentials")
 
         if protocol not in ["http", "https"]:
@@ -117,7 +118,8 @@ class AppOpticsConnection(object):
         headers['User-Agent'] = self._compute_ua()
         return headers
 
-    def _url_encode_params(self, params={}):
+    def _url_encode_params(self, params=None):
+        params = params or {}
         if not isinstance(params, dict):
             raise Exception("You must pass in a dictionary!")
         params_list = []
@@ -562,7 +564,7 @@ class AppOpticsConnection(object):
 
 
 def connect(api_key=None, hostname=HOSTNAME, base_path=BASE_PATH, sanitizer=sanitize_no_op,
-            protocol="https", tags={}):
+            protocol="https", tags=None):
     """
     Connect to AppOptics Metrics
     """

--- a/appoptics_metrics/__init__.py
+++ b/appoptics_metrics/__init__.py
@@ -213,20 +213,37 @@ class AppOpticsConnection(object):
         else:
             return resp
 
-    # Get a shallow copy of the top-level tag set
     def get_tags(self):
+        """
+        Get a shallow copy of the top-level tag set
+        :return:
+        """
         return dict(self.tags)
 
-    # Define the top-level tag set for posting measurements
     def set_tags(self, d):
+        """
+        Define the top-level tag set for posting measurements
+        :param d:
+        :return:
+        """
         self.tags = dict(d)    # Create a copy
 
-    # Add to the top-level tag set
     def add_tags(self, d):
+        """
+        Add to the top-level tag set
+        :param d:
+        :return:
+        """
         self.tags.update(d)
 
-    # Return all items for a "list" request
     def _get_paginated_results(self, entity, klass, **query_props):
+        """
+        Return all items for a "list" request
+        :param entity:
+        :param klass:
+        :param query_props:
+        :return:
+        """
         resp = self._mexe(entity, query_props=query_props)
 
         results = self._parse(resp, entity, klass)
@@ -343,7 +360,6 @@ class AppOpticsConnection(object):
         props.update({'name': name})
         props.update({'type': type})
         return self._mexe("metrics/%s" % self.sanitize(name), method="PUT", query_props=props)
-
 
     def update(self, name, **query_props):
         return self._mexe("metrics/%s" % self.sanitize(name), method="PUT", query_props=query_props)
@@ -516,9 +532,14 @@ class AppOpticsConnection(object):
         resp['space_id'] = space_id
         return Chart.from_dict(self, resp)
 
-    # Find a chart by name in a space. Return the first match, so if multiple
-    # charts have the same name, you'll only get the first one
     def find_chart(self, name, space):
+        """
+        Find a chart by name in a space. Return the first match, so if multiple
+        charts have the same name, you'll only get the first one
+        :param name:
+        :param space:
+        :return:
+        """
         charts = self.list_charts_in_space(space)
         for chart in charts:
             if chart.name and chart.name.lower() == name.lower():

--- a/appoptics_metrics/__init__.py
+++ b/appoptics_metrics/__init__.py
@@ -269,6 +269,16 @@ class AppOpticsConnection(object):
     def list_all_metrics(self, **query_props):
         return self._get_paginated_results("metrics", Metric, **query_props)
 
+    def submit_measurement(self, name, value, **query_props):
+        """
+        submit_measurement is an alias for submit()
+        :param name:
+        :param value:
+        :param query_props:
+        :return:
+        """
+        return self.submit(name, value, **query_props)
+
     def submit(self, name, value, **query_props):
         # silently ignore `type` for measurements submission
         query_props.pop("type", None)

--- a/appoptics_metrics/__init__.py
+++ b/appoptics_metrics/__init__.py
@@ -353,9 +353,6 @@ class AppOpticsConnection(object):
 
         return self._mexe("measurements/%s" % self.sanitize(name), method="GET", query_props=query_props)
 
-    def get_measurements(self, name, **query_props):
-        return self.get_tagged(name, **query_props)
-
     def get_composite(self, compose, **query_props):
         if self.get_tags():
             return self.get_composite_tagged(compose, **query_props)
@@ -382,13 +379,40 @@ class AppOpticsConnection(object):
         query_props['type'] = 'composite'
         return self.update(name, **query_props)
 
+    def create_metric(self, name, type="gauge", **props):
+        """
+        create_metric creates a new metric with the provided name and properties
+        :param name:
+        :param type:
+        :param props:
+        :return:
+        """
+        return self.create(name, type, **props)
+
     def create(self, name, type="gauge", **props):
         props.update({'name': name})
         props.update({'type': type})
         return self._mexe("metrics/%s" % self.sanitize(name), method="PUT", query_props=props)
 
+    def update_metric(self, name, **query_props):
+        """
+        update_metric updates the properties of a metric
+        :param name:
+        :param query_props:
+        :return:
+        """
+        return self.update(name, **query_props)
+
     def update(self, name, **query_props):
         return self._mexe("metrics/%s" % self.sanitize(name), method="PUT", query_props=query_props)
+
+    def delete_metric(self, names):
+        """
+        delete_metric deletes one or multiple metrics
+        :param names:
+        :return:
+        """
+        return self.delete(names)
 
     def delete(self, names):
         if isinstance(names, six.string_types):

--- a/appoptics_metrics/__init__.py
+++ b/appoptics_metrics/__init__.py
@@ -275,7 +275,7 @@ class AppOpticsConnection(object):
 
         if 'tags' in query_props or self.get_tags():
             self.submit_tagged(name, value, **query_props)
-        else: # at least one `tags` is required
+        else:  # at least one `tags` is required
             raise Exception('At least one tag is needed.')
 
     def submit_tagged(self, name, value, **query_props):

--- a/appoptics_metrics/aggregator.py
+++ b/appoptics_metrics/aggregator.py
@@ -16,7 +16,7 @@ class Aggregator(object):
         self.measurements = {}
         self.tagged_measurements = {}
         self.period = args.get('period')
-        self.measure_time = args.get('measure_time')
+        self.measure_time = args.get('time')
 
     # Get a shallow copy of the top-level tag set
     def get_tags(self):
@@ -88,13 +88,13 @@ class Aggregator(object):
             vals["name"] = metric_name
             body.append(vals)
 
-        result = {'gauges': body}
+        result = {'measurements': body}
         if self.source:
             result['source'] = self.source
 
         mt = self.floor_measure_time()
         if mt:
-            result['measure_time'] = mt
+            result['time'] = mt
 
         return result
 
@@ -160,7 +160,7 @@ class Aggregator(object):
         # Submit any legacy or tagged measurements to API
         # This will actually return an empty 200 response (no body)
         if self.measurements:
-            self.connection._mexe("metrics",
+            self.connection._mexe("measurements",
                                   method="POST",
                                   query_props=self.to_payload())
         if self.tagged_measurements:

--- a/appoptics_metrics/alerts.py
+++ b/appoptics_metrics/alerts.py
@@ -5,7 +5,7 @@ class Alert(object):
                  conditions=None, services=None, attributes=None, active=True, rearm_seconds=None):
         conditions = conditions or []
         services = services or []
-        attributes = attributes or []
+        attributes = attributes or {}
 
         self.connection = connection
         self.name = name

--- a/appoptics_metrics/alerts.py
+++ b/appoptics_metrics/alerts.py
@@ -2,7 +2,11 @@ class Alert(object):
     """AppOptics Alert Base class"""
 
     def __init__(self, connection, name, _id=None, description=None, version=2, md=False,
-                 conditions=[], services=[], attributes={}, active=True, rearm_seconds=None):
+                 conditions=None, services=None, attributes=None, active=True, rearm_seconds=None):
+        conditions = conditions or []
+        services = services or []
+        attributes = attributes or []
+
         self.connection = connection
         self.name = name
         self.description = description

--- a/appoptics_metrics/exceptions.py
+++ b/appoptics_metrics/exceptions.py
@@ -71,7 +71,7 @@ class ClientError(Exception):
                             messages.append(msg)
                     elif isinstance(error_list, dict):
                         for k in error_list:
-                            # e.g. "params: measure_time: "
+                            # e.g. "params: time: "
                             msg = "%s: %s: " % (key, k)
                             msg += self._flatten_error_message(error_list[k])
                             messages.append(msg)

--- a/appoptics_metrics/metrics.py
+++ b/appoptics_metrics/metrics.py
@@ -47,10 +47,8 @@ class Metric(object):
 
 class Gauge(Metric):
     """AppOptics Gauge metric"""
-    def add(self, value, source=None, **params):
+    def add(self, value, **params):
         """Add a new measurement to this gauge"""
-        if source:
-            params['source'] = source
         return self.connection.submit(self.name, value, type="gauge", **params)
 
     def what_am_i(self):

--- a/appoptics_metrics/metrics.py
+++ b/appoptics_metrics/metrics.py
@@ -26,8 +26,6 @@ class Metric(object):
 
         if metric_type == "gauge":
             cls = Gauge
-        elif metric_type == "counter":
-            cls = Counter
         elif metric_type == "composite":
             # Since we don't have a formal Composite class, use Gauge for now
             cls = Gauge
@@ -57,15 +55,3 @@ class Gauge(Metric):
 
     def what_am_i(self):
         return 'gauges'
-
-
-class Counter(Metric):
-    """AppOptics Counter metric"""
-    def add(self, value, source=None, **params):
-        if source:
-            params['source'] = source
-
-        return self.connection.submit(self.name, value, type="counter", **params)
-
-    def what_am_i(self):
-        return 'counters'

--- a/appoptics_metrics/queue.py
+++ b/appoptics_metrics/queue.py
@@ -1,3 +1,5 @@
+import copy
+
 class Queue(object):
     """Sending small amounts of measurements in a single HTTP request
     is inefficient. The payload is small and the overhead in the server
@@ -41,18 +43,17 @@ class Queue(object):
         """add measurements to the Q"""
         if 'tags' in query_props or len(self.tags) > 0 or len(self.connection.get_tags()) > 0:
             self.add_tagged(name, value, **query_props)
-        else:
-            nm = {}  # new measurement
-            nm['name'] = self.connection.sanitize(name)
-            nm['value'] = value
-
-            for pn, v in query_props.items():
-                nm[pn] = v
-
-            self._add_measurement(type, nm)
-            self._auto_submit_if_necessary()
+        else:  # No tags found
+            raise Exception('At least one tag is needed.')
 
     def add_tagged(self, name, value, **query_props):
+        """
+        add_tagged is deprecated, use add instead.
+        :param name:
+        :param value:
+        :param query_props:
+        :return:
+        """
         nm = {}  # new measurement
         nm['name'] = self.connection.sanitize(name)
         nm['sum'] = value

--- a/appoptics_metrics/queue.py
+++ b/appoptics_metrics/queue.py
@@ -17,7 +17,8 @@ class Queue(object):
     """
     MAX_MEASUREMENTS_PER_CHUNK = 300  # based docs; on POST /metrics
 
-    def __init__(self, connection, auto_submit_count=None, tags={}):
+    def __init__(self, connection, auto_submit_count=None, tags=None):
+        tags = tags or {}
         self.connection = connection
         self.tags = dict(tags)
         self.chunks = []

--- a/appoptics_metrics/queue.py
+++ b/appoptics_metrics/queue.py
@@ -82,7 +82,7 @@ class Queue(object):
             nm['name'] = name
             # Set measure_time
             if mt:
-                nm['measure_time'] = mt
+                nm['time'] = mt
             # Set source
             if aggregator.source:
                 nm['source'] = aggregator.source

--- a/appoptics_metrics/queue.py
+++ b/appoptics_metrics/queue.py
@@ -110,7 +110,7 @@ class Queue(object):
 
     def submit(self):
         for c in self.chunks:
-            self.connection._mexe("metrics", method="POST", query_props=c)
+            self.connection._mexe("measurements", method="POST", query_props=c)
         self.chunks = []
 
         for chunk in self.tagged_chunks:
@@ -131,7 +131,10 @@ class Queue(object):
 
     def _add_measurement(self, type, nm):
         if not self.chunks or self._num_measurements_in_current_chunk() == self.MAX_MEASUREMENTS_PER_CHUNK:
-            self.chunks.append({'gauges': [], 'counters': []})
+            self.chunks.append({'measurements': []})
+        # Dirty hack, the key `gauges` in the old API now becomes `measurements`
+        if type == 'gauge':
+            type = 'measurement'
         self.chunks[-1][type + 's'].append(nm)
 
     def _add_tagged_measurement(self, nm):
@@ -155,7 +158,7 @@ class Queue(object):
         else:
             if self.chunks:
                 cc = self.chunks[-1]
-                return len(cc['gauges']) + len(cc['counters'])
+                return len(cc['measurements'])
             else:
                 return 0
 

--- a/appoptics_metrics/spaces.py
+++ b/appoptics_metrics/spaces.py
@@ -52,7 +52,8 @@ class Space(object):
         chart = self.new_chart(name, **kwargs)
         return chart.save()
 
-    def add_line_chart(self, name, streams=[]):
+    def add_line_chart(self, name, streams=None):
+        streams = streams or []
         return self.add_chart(name, streams=streams)
 
     def add_single_line_chart(self, name, metric=None, source='*',
@@ -65,7 +66,8 @@ class Space(object):
             stream['summary_function'] = summary_function
         return self.add_line_chart(name, streams=[stream])
 
-    def add_stacked_chart(self, name, streams=[]):
+    def add_stacked_chart(self, name, streams=None):
+        streams = streams or []
         return self.add_chart(name, type='stacked', streams=streams)
 
     def add_single_stacked_chart(self, name, metric, source='*'):
@@ -127,12 +129,13 @@ class Chart(object):
     #   "use_log_yaxis": true
     # }
     def __init__(self, connection, name=None, id=None, type='line',
-                 space_id=None, streams=[],
+                 space_id=None, streams=None,
                  min=None, max=None,
                  label=None,
                  use_log_yaxis=None,
                  use_last_value=None,
                  related_space=None):
+        streams = streams or []
         self.connection = connection
         self.name = name
         self.type = type

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -131,15 +131,15 @@ class TestAppOpticsBasic(TestAppOpticsBase):
         q.submit()
 
         for t in range(1, 10):
-            q.add('temperature', randint(20, 40), measure_time=time.time() + t)
+            q.add('temperature', randint(20, 40), time=time.time() + t)
         q.submit()
 
         for t in range(1, 10):
-            q.add('temperature', randint(20, 40), source='upstairs', measure_time=time.time() + t)
+            q.add('temperature', randint(20, 40), source='upstairs', time=time.time() + t)
         q.submit()
 
         for t in range(1, 50):
-            q.add('temperature', randint(20, 30), source='downstairs', measure_time=time.time() + t)
+            q.add('temperature', randint(20, 30), source='downstairs', time=time.time() + t)
         q.submit()
         self.conn.delete('temperature')
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -105,11 +105,6 @@ class TestAppOpticsBasic(TestAppOpticsBase):
         self._add_and_verify_metric(name, desc)
         self._delete_and_verify_metric(name)
 
-    # def test_create_and_delete_counter(self):
-    #     name, desc = 'Test_counter', 'Test Counter to be removed'
-    #     self._add_and_verify_metric(name, desc, type='counter')
-    #     self._delete_and_verify_metric(name)
-
     def test_batch_delete(self):
         name_one, desc_one = 'Test_one', 'Test gauge to be removed'
         name_two, desc_two = 'Test_two', 'Test gauge2 to be removed'
@@ -118,9 +113,9 @@ class TestAppOpticsBasic(TestAppOpticsBase):
         self._delete_and_verify_metric([name_one, name_two])
 
     def test_save_gauge_metrics(self):
-        name, desc = 'Test', 'Test Gauge to be removed'
-        self.conn.create_metric(name, "gauge", description=desc)
-        self.conn.create_metric(name, "gauge", description=desc)
+        name = 'Test'
+        self.conn.submit(name, 10, tags={"region": "us-east-1"})
+        self.conn.submit(name, 20, tags={"region": "us-east-1"})
         self.conn.delete(name)
 
     def test_send_batch_gauge_measurements(self):
@@ -159,13 +154,6 @@ class TestAppOpticsBasic(TestAppOpticsBase):
 
     def test_submit_empty_queue(self):
         self.conn.new_queue().submit()
-
-    # def test_send_batch_counter_measurements(self):
-    #     q = self.conn.new_queue()
-    #     for nr in range(1, 2):
-    #         q.add('num_req', nr, type='counter', source='server1', measure_time=time.time() - 1)
-    #         q.add('num_req', nr, type='counter', source='server2', measure_time=time.time() - 1)
-    #     q.submit()
 
     def test_update_metrics_attributes(self):
         name, desc = 'Test', 'A great gauge.'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -67,10 +67,9 @@ class TestAppOpticsBasic(TestAppOpticsBase):
     def _add_and_verify_metric(self, name, desc, connection=None, type='gauge'):
         if not connection:
             connection = self.conn
-        connection.create(name, type=type, description=desc, tags={"region": "us-east-1"})
+        connection.create_metric(name, type=type, description=desc, tags={"region": "us-east-1"})
         self.wait_for_replication()
         metric = connection.get(name)
-        six.print_("name: ", metric.name, " sanitize: ", connection.sanitize(name).lower())
         assert metric and metric.name.lower() == connection.sanitize(name).lower()
         assert metric.description.lower() == desc.lower()
         return metric
@@ -120,8 +119,8 @@ class TestAppOpticsBasic(TestAppOpticsBase):
 
     def test_save_gauge_metrics(self):
         name, desc = 'Test', 'Test Gauge to be removed'
-        self.conn.create(name, "gauge", description=desc)
-        self.conn.create(name, "gauge", description=desc)
+        self.conn.create_metric(name, "gauge", description=desc)
+        self.conn.create_metric(name, "gauge", description=desc)
         self.conn.delete(name)
 
     def test_send_batch_gauge_measurements(self):
@@ -170,7 +169,7 @@ class TestAppOpticsBasic(TestAppOpticsBase):
 
     def test_update_metrics_attributes(self):
         name, desc = 'Test', 'A great gauge.'
-        self.conn.create(name, 'gauge', description=desc)
+        self.conn.create_metric(name, 'gauge', description=desc)
         self.wait_for_replication()
         gauge = self.conn.get(name)
         assert gauge and gauge.name == name
@@ -189,7 +188,7 @@ class TestAppOpticsBasic(TestAppOpticsBase):
     def test_sanitized_update(self):
         name, desc = 'a' * 1000, 'too long, really'
         new_desc = 'different'
-        self.conn_sanitize.create(name, "gauge", description=desc)
+        self.conn_sanitize.create_metric(name, "gauge", description=desc)
         gauge = self.conn_sanitize.get(name)
         assert gauge.description == desc
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -135,11 +135,11 @@ class TestAppOpticsBasic(TestAppOpticsBase):
         q.submit()
 
         for t in range(1, 10):
-            q.add('temperature', randint(20, 40), source='upstairs', time=time.time() + t)
+            q.add('temperature', randint(20, 40), time=time.time() + t)
         q.submit()
 
         for t in range(1, 50):
-            q.add('temperature', randint(20, 30), source='downstairs', time=time.time() + t)
+            q.add('temperature', randint(20, 30), time=time.time() + t)
         q.submit()
         self.conn.delete('temperature')
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -70,9 +70,9 @@ class TestAppOpticsBasic(TestAppOpticsBase):
         connection.create(name, type=type, description=desc, tags={"region": "us-east-1"})
         self.wait_for_replication()
         metric = connection.get(name)
-        print("name: ", metric.name, " sanitize: ", connection.sanitize(name).lower())
-        assert metric and metric.name == connection.sanitize(name).lower()
-        assert metric.description == desc
+        six.print_("name: ", metric.name, " sanitize: ", connection.sanitize(name).lower())
+        assert metric and metric.name.lower() == connection.sanitize(name).lower()
+        assert metric.description.lower() == desc.lower()
         return metric
 
     def _delete_and_verify_metric(self, names, connection=None):

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -73,7 +73,8 @@ class MockServer(object):
             p_to_metric = self.metrics[type + 's'][name]
             # Seems we don't support `source` now, all measurements go to `unassgined`
             source = "unassigned"
-            p_to_metric['measurements'][source] = []
+            if source not in p_to_metric['measurements']:
+                p_to_metric['measurements'][source] = []
             p_to_metric['measurements'][source].append({"value": value})
 
         return ''
@@ -387,7 +388,7 @@ class MockServer(object):
             raise Exception('md get requires a start or duration parameter')
 
         measurements = [t for t in self.tagged_measurements[name][tag][value] if (t[0] >= start and t[0] <= end)]
-        measurements.sort(key=lambda x: x[1])
+        # measurements.sort(key=lambda x: x[1])
         m_dicts = [{'time': t[0], 'value': t[1]} for t in measurements if len(t) > 0]
 
         response = {}

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -426,12 +426,6 @@ class MockServer(object):
         answer['query'] = {}
         return answer
 
-    def add_batch_of_measurements(self, gc_measurements):
-        for gm in gc_measurements['measurements']:
-            new_gauge = {'name': gm['name'], 'type': gm['type']}
-            self.add_gauge_to_store(new_gauge)
-            self.add_gauge_measurement(gm)
-
     def add_metric_to_store(self, g, m_type):
         if g['name'] not in self.metrics[m_type + 's']:
             g['type'] = m_type
@@ -441,10 +435,6 @@ class MockServer(object):
                 g['attributes'] = {}
             g['measurements'] = {}
             self.metrics[m_type + 's'][g['name']] = g
-
-    def delete_gauge(self, name):
-        del self.gauges[name]
-        return ''
 
     def _chart_ids_for_space_id(self, space_id):
         return [c['id'] for c in self.spaces[int(space_id)]['charts']]
@@ -496,9 +486,6 @@ class MockResponse(object):
             d = parse_qs(query)
             # Flatten since parse_qs likes to build lists of values
             payload = {k: v[0] for k, v in six.iteritems(d)}
-            # The new API returns metric name with measurements retrieval results
-            # so we need to mock it here. Put it into payload to avoid adding a new
-            # parameter.
             return server.get_tagged_measurements(self._extract_from_url(tagged=True), payload)
         elif self._req_is_list_of_alerts():
             return server.list_of_alerts()

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -131,9 +131,6 @@ class MockServer(object):
         else:
             return json.dumps(self.instruments[int(_id)]).encode('utf-8')
 
-    def __an_empty_list_metrics(self):
-        answer = {}
-
     def create_alert(self, payload):
         self.last_a_id += 1
         payload["id"] = self.last_a_id

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -12,7 +12,7 @@ class MockServer(object):
         self.clean()
 
     def clean(self):
-        self.metrics = {'gauges': OrderedDict(), 'counters': OrderedDict()}
+        self.metrics = {'measurements': OrderedDict()}
         self.alerts = OrderedDict()
         self.services = OrderedDict()
         self.spaces = OrderedDict()
@@ -28,14 +28,12 @@ class MockServer(object):
 
     def list_of_metrics(self):
         answer = self.__an_empty_list_metrics()
-        for gn, g in self.metrics['gauges'].items():
+        for gn, g in self.metrics['measurements'].items():
             answer['metrics'].append(g)
-        for cn, c in self.metrics['counters'].items():
-            answer['metrics'].append(c)
         return json.dumps(answer).encode('utf-8')
 
     def create_metric(self, payload):
-        for metric_type in ['gauge', 'counter']:
+        for metric_type in ['gauge']:
             for metric in payload.get(metric_type + 's', []):
                 name = metric['name']
                 self.add_metric_to_store(metric, metric_type)
@@ -370,12 +368,10 @@ class MockServer(object):
         return ''
 
     def get_metric(self, name, payload):
-        gauges = self.metrics['gauges']
-        counters = self.metrics['counters']
+        gauges = self.metrics['measurements']
+        metric = ""
         if name in gauges:
             metric = gauges[name]
-        if name in counters:
-            metric = counters[name]
         return json.dumps(metric).encode('utf-8')
 
     def get_tagged_measurements(self, name, payload):
@@ -415,8 +411,7 @@ class MockServer(object):
         return json.dumps(response).encode('utf-8')
 
     def delete_metric(self, name, payload):
-        gauges = self.metrics['gauges']
-        counters = self.metrics['counters']
+        gauges = self.metrics['measurements']
         if not payload:
             payload = {}
         if 'names' not in payload:
@@ -428,8 +423,6 @@ class MockServer(object):
         for rm_name in payload['names']:
             if rm_name in gauges:
                 del gauges[rm_name]
-            if rm_name in counters:
-                del counters[rm_name]
         return ''
 
     def __an_empty_list_metrics(self):
@@ -439,7 +432,7 @@ class MockServer(object):
         return answer
 
     def add_batch_of_measurements(self, gc_measurements):
-        for gm in gc_measurements['gauges']:
+        for gm in gc_measurements['measurements']:
             new_gauge = {'name': gm['name'], 'type': gm['type']}
             self.add_gauge_to_store(new_gauge)
             self.add_gauge_measurement(gm)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -60,7 +60,7 @@ class TestAggregator(unittest.TestCase):
 
     def test_initialize_measure_time(self):
         assert Aggregator(self.conn).measure_time is None
-        assert Aggregator(self.conn, measure_time=12345).measure_time == 12345
+        assert Aggregator(self.conn, time=12345).measure_time == 12345
 
     def test_add_single_measurement(self):
         m = 'metric.one'
@@ -155,7 +155,6 @@ class TestAggregator(unittest.TestCase):
 
     def test_submit(self):
         self.agg.add('test.metric', 42)
-        self.agg.add('test.metric', 10)
         resp = self.agg.submit()
         # Doesn't return a body
         assert resp is None
@@ -181,7 +180,7 @@ class TestAggregator(unittest.TestCase):
         self.agg.measure_time = mt
         self.agg.period = None
         self.agg.add("foo", 42)
-        assert 'measure_time' in self.agg.to_payload()
+        assert 'time' in self.agg.to_payload()
         assert self.agg.to_payload()['time'] == mt
 
     def test_measure_time_not_in_payload(self):
@@ -224,19 +223,6 @@ class TestAggregator(unittest.TestCase):
         self.agg.measure_time = 1418838418
         self.agg.period = 60
         assert self.agg.to_payload()['time'] == 1418838360
-
-    def test_submit_side_by_side(self):
-        # Tagged and untagged measurements should be handled as separate
-        self.agg.add_tags({'hostname': 'web-1'})
-        self.agg.add('test.metric', 42)
-        self.agg.add_tagged('test.metric', 10)
-        self.agg.submit()
-
-        gauge = self.conn.get('test.metric', duration=60)
-        assert len(gauge.measurements['unassigned']) == 1
-
-        resp = self.conn.get_tagged('test.metric', duration=60, tags_search="hostname=web-1")
-        assert len(resp['series']) == 1
 
 
 if __name__ == '__main__':

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -182,13 +182,13 @@ class TestAggregator(unittest.TestCase):
         self.agg.period = None
         self.agg.add("foo", 42)
         assert 'measure_time' in self.agg.to_payload()
-        assert self.agg.to_payload()['measure_time'] == mt
+        assert self.agg.to_payload()['time'] == mt
 
     def test_measure_time_not_in_payload(self):
         self.agg.measure_time = None
         self.agg.period = None
         self.agg.add("foo", 42)
-        assert 'measure_time' not in self.agg.to_payload()
+        assert 'time' not in self.agg.to_payload()
 
     def test_floor_measure_time(self):
         # 2014-12-17 17:46:58 UTC
@@ -223,7 +223,7 @@ class TestAggregator(unittest.TestCase):
         # This will occur only if period is set
         self.agg.measure_time = 1418838418
         self.agg.period = 60
-        assert self.agg.to_payload()['measure_time'] == 1418838360
+        assert self.agg.to_payload()['time'] == 1418838360
 
     def test_submit_side_by_side(self):
         # Tagged and untagged measurements should be handled as separate

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -109,20 +109,19 @@ class TestAggregator(unittest.TestCase):
         self.agg.add('test.metric', 42)
         self.agg.add('test.metric', 43)
         assert self.agg.to_payload() == {
-            'gauges': [
+            'measurements': [
                 {'name': 'test.metric', 'count': 2, 'sum': 85, 'min': 42, 'max': 43}
             ],
             'source': 'mysource'
         }
-        assert 'gauges' in self.agg.to_payload()
-        assert 'counters' not in self.agg.to_payload()
+        assert 'measurements' in self.agg.to_payload()
 
     def test_to_payload_no_source(self):
         self.agg.source = None
         self.agg.add('test.metric', 42)
 
         assert self.agg.to_payload() == {
-            'gauges': [
+            'measurements': [
                 {
                     'name': 'test.metric',
                     'count': 1,

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -12,7 +12,7 @@ appoptics_metrics.HTTPSConnection = MockConnect
 
 class ChartsTest(unittest.TestCase):
     def setUp(self):
-        self.conn = appoptics_metrics.connect('key_test')
+        self.conn = appoptics_metrics.connect('key_test', tags={"region": "us-east-1"})
         server.clean()
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -48,11 +48,11 @@ class TestClientError(unittest.TestCase):
     def test_parse_error_message_params(self):
         error_resp = {
             "errors": {
-                "params": {"measure_time": ["too far in past"]}
+                "params": {"time": ["too far in past"]}
             }
         }
         ex = exceptions.ClientError(400, error_resp)
-        self.assertEqual("params: measure_time: too far in past", ex._parse_error_message())
+        self.assertEqual("params: time: too far in past", ex._parse_error_message())
 
     def test_parse_error_message_params_multi_message(self):
         error_resp = {
@@ -67,14 +67,14 @@ class TestClientError(unittest.TestCase):
         error_resp = {
             "errors": {
                 "params": {
-                    "measure_time": ["too far in past"],
+                    "time": ["too far in past"],
                     "name": "mymetricname"
                 }
             }
         }
         ex = exceptions.ClientError(400, error_resp)
         msg = ex._parse_error_message()
-        self.assertRegexpMatches(msg, "params: measure_time: too far in past")
+        self.assertRegexpMatches(msg, "params: time: too far in past")
         self.assertRegexpMatches(msg, "params: name: mymetricname")
 
     def test_parse_error_message_params_multiple_2nd_level(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -114,6 +114,13 @@ class TestAppOptics(unittest.TestCase):
         assert len(gauge['series'][0]['measurements']) == 2
         assert gauge['series'][0]['measurements'][-1]['value'] == 1
 
+        self.conn.submit(name, 5)
+        gauge = self.conn.get_measurements(name, duration=86400, tags=tags)
+
+        assert gauge.get('name') == name
+        assert len(gauge['series'][0]['measurements']) == 3
+        assert gauge['series'][0]['measurements'][-1]['value'] == 5
+
     def test_md_inherit_tags(self):
         self.conn.set_tags({'company': 'AppOptics', 'hi': 'four'})
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,7 +7,6 @@ except ImportError:
 import appoptics_metrics
 import time
 from mock_connection import MockConnect, server
-from appoptics_metrics.metrics import Gauge
 
 # logging.basicConfig(level=logging.DEBUG)
 # Mock the server

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,34 +78,6 @@ class TestAppOptics(unittest.TestCase):
         assert metrics[1].name == 'gauge_2'
         assert metrics[1].description == 'desc 2'
 
-    def test_list_metrics_adding_counter_metrics(self):
-        self.conn.submit('c1', 10, 'counter', description='counter desc 1')
-        self.conn.submit('c2', 20, 'counter', description='counter desc 2')
-        # Get all metrics
-        metrics = self.conn.list_metrics()
-
-        assert len(metrics) == 2
-
-        assert isinstance(metrics[0], appoptics_metrics.metrics.Counter)
-        assert metrics[0].name == 'c1'
-        assert metrics[0].description == 'counter desc 1'
-
-        assert isinstance(metrics[1], appoptics_metrics.metrics.Counter)
-        assert metrics[1].name == 'c2'
-        assert metrics[1].description == 'counter desc 2'
-
-    def test_list_metrics_adding_one_counter_one_gauge(self):
-        self.conn.submit('gauge1', 10)
-        self.conn.submit('counter2', 20, type='counter', description="desc c2")
-        # Get all metrics
-        metrics = self.conn.list_metrics()
-        assert isinstance(metrics[0], appoptics_metrics.metrics.Gauge)
-        assert metrics[0].name == 'gauge1'
-
-        assert isinstance(metrics[1], appoptics_metrics.metrics.Counter)
-        assert metrics[1].name == 'counter2'
-        assert metrics[1].description == 'desc c2'
-
     def test_deleting_a_gauge(self):
         self.conn.submit('test', 100)
         assert len(self.conn.list_metrics()) == 1
@@ -119,12 +91,6 @@ class TestAppOptics(unittest.TestCase):
         self.conn.delete(['test', 'test2'])
         assert len(self.conn.list_metrics()) == 0
 
-    def test_deleting_a_counter(self):
-        self.conn.submit('test', 200, type='counter')
-        assert len(self.conn.list_metrics()) == 1
-        self.conn.delete('test')
-        assert len(self.conn.list_metrics()) == 0
-
     def test_get_gauge_basic(self):
         name, desc = '1', 'desc 1'
         self.conn.submit(name, 10, description=desc)
@@ -135,16 +101,6 @@ class TestAppOptics(unittest.TestCase):
         assert len(gauge.measurements['unassigned']) == 1
         assert gauge.measurements['unassigned'][0]['value'] == 10
 
-    def test_get_counter_basic(self):
-        name, desc = 'counter1', 'count desc 1'
-        self.conn.submit(name, 20, type='counter', description=desc)
-        counter = self.conn.get(name)
-        assert isinstance(counter, appoptics_metrics.metrics.Counter)
-        assert counter.name == name
-        assert counter.description == desc
-        assert len(counter.measurements['unassigned']) == 1
-        assert counter.measurements['unassigned'][0]['value'] == 20
-
     def test_send_single_measurements_for_gauge_with_source(self):
         name, desc, src = 'Test', 'A Test Gauge.', 'from_source'
         self.conn.submit(name, 10, description=desc, source=src)
@@ -153,32 +109,6 @@ class TestAppOptics(unittest.TestCase):
         assert gauge.description == desc
         assert len(gauge.measurements[src]) == 1
         assert gauge.measurements[src][0]['value'] == 10
-
-    def test_send_single_measurements_for_counter_with_source(self):
-        name, desc, src = 'Test', 'A Test Counter.', 'from_source'
-        self.conn.submit(name, 111, type='counter', description=desc, source=src)
-        counter = self.conn.get(name)
-        assert counter.name == name
-        assert counter.description == desc
-        assert len(counter.measurements[src]) == 1
-        assert counter.measurements[src][0]['value'] == 111
-
-    def test_add_in_counter(self):
-        name, desc, src = 'Test', 'A Test Counter.', 'from_source'
-        self.conn.submit(name, 111, type='counter', description=desc, source=src)
-        counter = self.conn.get(name)
-        assert counter.name == name
-        assert counter.description == desc
-        assert len(counter.measurements[src]) == 1
-        assert counter.measurements[src][0]['value'] == 111
-
-        counter.add(1, source=src)
-
-        counter = self.conn.get(name)
-        assert counter.name == name
-        assert counter.description == desc
-        assert len(counter.measurements[src]) == 2
-        assert counter.measurements[src][-1]['value'] == 1
 
     def test_add_in_gauge(self):
         name, desc, src = 'Test', 'A Test Gauge.', 'from_source'

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -146,16 +146,7 @@ class TestAppOpticsQueue(unittest.TestCase):
     def test_default_type_measurement(self):
         q = self.q
         q.add('temperature', 22.1)
-        assert len(q._current_chunk()['gauges']) == 1
-        assert len(q._current_chunk()['counters']) == 0
-
-    def test_single_measurement_counter(self):
-        q = self.q
-        q.add('num_requests', 2000, type='counter')
-        assert len(q.chunks) == 1
-        assert q._num_measurements_in_current_chunk() == 1
-        assert len(q._current_chunk()['gauges']) == 0
-        assert len(q._current_chunk()['counters']) == 1
+        assert len(q._current_chunk()['measurements']) == 1
 
     def test_num_metrics_in_queue(self):
         q = self.q
@@ -165,7 +156,7 @@ class TestAppOpticsQueue(unittest.TestCase):
         assert q._num_measurements_in_queue() == 290
         # Now ensure multiple chunks
         for _ in range(100):
-            q.add('num_requests', randint(100, 300), type='counter')
+            q.add('num_requests', randint(100, 300), type='gauge')
         assert q._num_measurements_in_queue() == 390
 
     def test_auto_submit_on_metric_count(self):
@@ -260,7 +251,7 @@ class TestAppOpticsQueue(unittest.TestCase):
         a.add('bar', 37)
         q.add_aggregator(a)
 
-        gauges = q.chunks[0]['gauges']
+        gauges = q.chunks[0]['measurements']
         names = [g['name'] for g in gauges]
 
         assert len(q.chunks) == 1

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -139,28 +139,28 @@ class TestAppOpticsQueue(unittest.TestCase):
 
     def test_single_measurement_gauge(self):
         q = self.q
-        q.add('temperature', 22.1)
-        assert len(q.chunks) == 1
-        assert q._num_measurements_in_current_chunk() == 1
+        q.add('temperature', 22.1, tags={'sky': 'blue'})
+        assert len(q.tagged_chunks) == 1
+        assert q._num_measurements_in_current_chunk(tagged=True) == 1
 
     def test_default_type_measurement(self):
         q = self.q
-        q.add('temperature', 22.1)
-        assert len(q._current_chunk()['measurements']) == 1
+        q.add('temperature', 22.1, tags={'sky': 'blue'})
+        assert len(q._current_chunk(tagged=True)['measurements']) == 1
 
     def test_num_metrics_in_queue(self):
         q = self.q
         # With only one chunk
         for _ in range(q.MAX_MEASUREMENTS_PER_CHUNK - 10):
-            q.add('temperature', randint(20, 30))
+            q.add('temperature', randint(20, 30), tags={'sky': 'blue'})
         assert q._num_measurements_in_queue() == 290
         # Now ensure multiple chunks
         for _ in range(100):
-            q.add('num_requests', randint(100, 300), type='gauge')
+            q.add('num_requests', randint(100, 300), type='gauge', tags={'sky': 'blue'})
         assert q._num_measurements_in_queue() == 390
 
     def test_auto_submit_on_metric_count(self):
-        q = self.conn.new_queue(auto_submit_count=10)
+        q = self.conn.new_queue(auto_submit_count=10, tags={'sky': 'blue'})
         for _ in range(9):
             q.add('temperature', randint(20, 30))
         assert q._num_measurements_in_queue() == 9
@@ -174,18 +174,18 @@ class TestAppOpticsQueue(unittest.TestCase):
     def test_reach_chunk_limit(self):
         q = self.q
         for i in range(1, q.MAX_MEASUREMENTS_PER_CHUNK + 1):
-            q.add('temperature', randint(20, 30))
-        assert len(q.chunks) == 1
-        assert q._num_measurements_in_current_chunk() == q.MAX_MEASUREMENTS_PER_CHUNK
+            q.add('temperature', randint(20, 30), tags={'sky': 'blue'})
+        assert len(q.tagged_chunks) == 1
+        assert q._num_measurements_in_current_chunk(tagged=True) == q.MAX_MEASUREMENTS_PER_CHUNK
 
-        q.add('temperature', 40)  # damn is pretty hot :)
-        assert q._num_measurements_in_current_chunk() == 1
-        assert len(q.chunks) == 2
+        q.add('temperature', 40, tags={'sky': 'blue'})  # damn is pretty hot :)
+        assert q._num_measurements_in_current_chunk(tagged=True) == 1
+        assert len(q.tagged_chunks) == 2
 
     def test_submit_context_manager(self):
         try:
             with self.conn.new_queue() as q:
-                q.add('temperature', 32)
+                q.add('temperature', 32, tags={'sky': 'blue'})
                 raise ValueError
         except ValueError:
             gauge = self.conn.get('temperature', resolution=1, count=2)
@@ -195,7 +195,7 @@ class TestAppOpticsQueue(unittest.TestCase):
 
     def test_submit_one_measurement_batch_mode(self):
         q = self.q
-        q.add('temperature', 22.1)
+        q.add('temperature', 22.1, tags={'sky': 'blue'})
         q.submit()
         metrics = self.conn.list_metrics()
         assert len(metrics) == 1
@@ -205,7 +205,7 @@ class TestAppOpticsQueue(unittest.TestCase):
         assert len(gauge.measurements['unassigned']) == 1
 
         # Add another measurements for temperature
-        q.add('temperature', 23)
+        q.add('temperature', 23, tags={'sky': 'blue'})
         q.submit()
         metrics = self.conn.list_metrics()
         assert len(metrics) == 1
@@ -222,7 +222,7 @@ class TestAppOpticsQueue(unittest.TestCase):
         assert len(metrics) == 0
 
         for t in range(1, q.MAX_MEASUREMENTS_PER_CHUNK + 1):
-            q.add('temperature', t)
+            q.add('temperature', t, tags={'sky': 'blue'})
         q.submit()
         metrics = self.conn.list_metrics()
         assert len(metrics) == 1
@@ -233,7 +233,7 @@ class TestAppOpticsQueue(unittest.TestCase):
             assert gauge.measurements['unassigned'][t - 1]['value'] == t
 
         for cl in range(1, q.MAX_MEASUREMENTS_PER_CHUNK + 1):
-            q.add('cpu_load', cl)
+            q.add('cpu_load', cl, tags={'sky': 'blue'})
         q.submit()
         metrics = self.conn.list_metrics()
         assert len(metrics) == 2
@@ -348,14 +348,15 @@ class TestAppOpticsQueue(unittest.TestCase):
         assert measurements[1]['value'] == 20
 
     def test_md_auto_submit_on_metric_count(self):
-        q = self.conn.new_queue(auto_submit_count=2)
+        q = self.conn.new_queue(auto_submit_count=2, tags={"region": "us-east-1"})
 
+        # Use the queue's default tag as at least one tag is needed.
         q.add('untagged_cpu', 10)
         q.add_tagged('tagged_cpu', 20, tags={'hostname': 'web-2'})
 
         assert q._num_measurements_in_queue() == 0
 
-        gauge = self.conn.get('untagged_cpu', duration=60)
+        gauge = self.conn.get_metric('untagged_cpu', duration=60)
         assert len(gauge.measurements['unassigned']) == 1
 
         resp = self.conn.get_tagged('tagged_cpu', duration=60, tags_search="hostname=web-2")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -264,11 +264,11 @@ class TestAppOpticsQueue(unittest.TestCase):
         assert gauges[1]['source'] == 'mysource'
 
         # All gauges should have the same measure_time
-        assert 'measure_time' in gauges[0]
-        assert 'measure_time' in gauges[1]
+        assert 'time' in gauges[0]
+        assert 'time' in gauges[1]
 
         # Test that time was snapped to 10s
-        assert gauges[0]['measure_time'] % 10 == 0
+        assert gauges[0]['time'] % 10 == 0
 
     def test_md_submit(self):
         q = self.q

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -90,7 +90,7 @@ class TestStreamModel(unittest.TestCase):
         s = Stream(**attrs)
         # color is a known attribute
         self.assertEqual(s.color, '#f00')
-        self.assertEqual(s.something, 'foo')
+        self.assertEqual(getattr(s, "something"), 'foo')
 
     def test_get_payload(self):
         self.assertEqual(Stream(metric='my.metric').get_payload(),


### PR DESCRIPTION
0. Fixed the logic of some integration test cases.
1. Removed `counters` and `Counter` class.
2. Made changes to the measurement submission:
        a) Changed message format (e.g., changed from `gauges` to `measurements`.
        b) Raise an exception for measurements without a `tags`
        c) Silently ignore `type` in measurements submission
    `description` and `source` are gone in measurement message of the AppOptics API but the client library just pass them to the server and let it decides

3. Changed endpoints from `metrics` to `measurements` for measurements submission
4. Change methods from `POST` to `PUT` for metrics creation.
5. Added checks to the measurements submission method, reject measurements without tags
6. Fixed the problems of mutable default values ([], {}, etc.)
7. Fixed some other PEP8 warnings.
8. Fixed errors of unit test cases